### PR TITLE
build(deps): bump undici and vitest-environment-miniflare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "miniflare": "3.20230918.0",
         "typescript": "^4.9.5",
         "vitest": "^0.31.4",
-        "vitest-environment-miniflare": "^2.14.1",
+        "vitest-environment-miniflare": "^2.14.2",
         "wrangler": "^3.19.0"
       },
       "engines": {
@@ -616,198 +616,138 @@
       "dev": true
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.1.tgz",
-      "integrity": "sha512-f/o6UBV6UX+MlhjcEch73/wjQvvNo37dgYmP6Pn2ax1/mEHhJ7allNAqenmonT4djNeyB3eEYV3zUl54wCEwrg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.2.tgz",
+      "integrity": "sha512-XH218Y2jxSOfxG8EyuprBKhI/Fn6xLrb9A39niJBlzpiKXqr8skl/sy/sUL5tfvqEbEnqDagGne8zEcjM+1fBg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
-    "node_modules/@miniflare/cache/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/core": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.1.tgz",
-      "integrity": "sha512-d+SGAda/VoXq+SKz04oq8ATUwQw5755L87fgPR8pTdR2YbWkxdbmEm1z2olOpDiUjcR86aN6NtCjY6tUC7fqaw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.2.tgz",
+      "integrity": "sha512-n/smm5ZTg7ilGM4fxO7Gxhbe573oc8Za06M3b2fO+lPWqF6NJcEKdCC+sJntVFbn3Cbbd2G1ChISmugPfmlCkQ==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/watcher": "2.14.1",
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/watcher": "2.14.2",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "urlpattern-polyfill": "^4.0.3"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
-    "node_modules/@miniflare/core/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/d1": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.1.tgz",
-      "integrity": "sha512-MulDDBsDD8o5DwiqdMeJZy2vLoMji+NWnLcuibSag2mayA0LJcp0eHezseZNkW+knciWR1gMP8Xpa4Q1KwkbKA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.2.tgz",
+      "integrity": "sha512-3NPJyBLbFfzz9VAAdIZrDRdRpyslVCJoZHQk0/0CX3z2mJIfcQzjZhox2cYCFNH8NMJ7pRg6AeSMPYAnDKECDg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.1.tgz",
-      "integrity": "sha512-T+oHGw5GcEIilkzrf0xDES7jzLVqcXJzSGsEIWqnBFLtdlKmrZF679ulRLBbyMVgvpQz6FRONh9jTH1XIiuObQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.2.tgz",
+      "integrity": "sha512-BfK+ZkJABoi7gd/O6WbpsO4GrgW+0dmOBWJDlNBxQ7GIpa+w3n9+SNnrYUxKzWlPSvz+TfTTk381B1z/Z87lPw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1",
-        "undici": "5.20.0"
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2",
+        "undici": "5.28.2"
       },
       "engines": {
         "node": ">=16.13"
-      }
-    },
-    "node_modules/@miniflare/durable-objects/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.1.tgz",
-      "integrity": "sha512-vp4uZXuEKhtIaxoXa7jgDAPItlzjbfoUqYWp+fwDKv4J4mfQnzzs/5hwjbE7+Ihm/KNI0zNi8P0sSWjIRFl6ng==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.2.tgz",
+      "integrity": "sha512-tu0kd9bj38uZ04loHb3sMI8kzUzZPgPOAJEdS9zmdSPh0uOkjCDf/TEkKsDdv2OFysyb0DRsIrwhPqCTIrPf1Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
-    "node_modules/@miniflare/html-rewriter/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/kv": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.1.tgz",
-      "integrity": "sha512-Gp07Wcszle7ptsoO8mCtKQRs0AbQnYo1rgnxUcsTL3xJJaHXEA/B9EKSADS2XzJMeY4PgUOHU6Rf08OOF2yWag==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.2.tgz",
+      "integrity": "sha512-3rs4cJOGACT/U7NH7j4KD29ugXRYUiM0aGkvOEdFQtChXLsYClJljXpezTfJJxBwZjdS4F2UFTixtFcHp74UfA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.1.tgz",
-      "integrity": "sha512-uBzrbBkIgtNoztDpmMMISg/brYtxLHRE7oTaN8OVnq3bG+3nF9kQC42HUz+Vg+sf65UlvhSaqkjllgx+fNtOxQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.2.tgz",
+      "integrity": "sha512-OylkRs4lOWKvGnX+Azab3nx+1qwC87M36/hkgAU1RRvVDCOxOrYLvNLUczFfgmgMBwpYsmmW8YOIASlI3p4Qgw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.1.tgz",
-      "integrity": "sha512-grOMnGf2XSicbgxMYMBfWE37k/e7l5NnwXZIViQ+N06uksp+MLA8E6yKQNtvrWQS66TM8gBvMnWo96OFmYjb6Q==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.2.tgz",
+      "integrity": "sha512-uuc7dx6OqSQT8i0F2rsigfizXmInssRvvJAjoi1ltaNZNJCHH9l1PwHfaNc/XAuDjYmiCjtHDaPdRvZU9g9F3g==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0"
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "undici": "5.28.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
-    "node_modules/@miniflare/r2/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.1.tgz",
-      "integrity": "sha512-UobsGM0ICVPDlJD54VPDSx0EXrIY3nJMXBy2zIFuuUOz4hQKXvMQ6jtAlJ8UNKer+XXI3Mb/9R/gfU8r6kxIMA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.2.tgz",
+      "integrity": "sha512-WlyxAQ+bv/9Pm/xnbpgAg7RNX4pz/q3flytUoo4z4OrRmNEuXrbMUsJZnH8dziqzrZ2gCLkYIEzeaTmSQKp5Jg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.1.tgz",
-      "integrity": "sha512-73GnLtWn5iP936ctE6ZJrMqGu134KOoIIveq5Yd/B+NnbFfzpuzjCpkLrnqjkDdsxDbruXSb5eTR/SmAdpJxZQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.2.tgz",
+      "integrity": "sha512-dDnYIztz10zDQjaFJ8Gy9UaaBWZkw3NyhFdpX6tAeyPA/2lGvkftc42MYmNi8s5ljqkZAtKgWAJnSf2K75NCJw==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -820,105 +760,93 @@
       }
     },
     "node_modules/@miniflare/shared-test-environment": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.14.1.tgz",
-      "integrity": "sha512-hfactEWiHuHOmE29XFG8oLNCF6+HqjD6Mb80CzidcVmLlBTEtSC3PEF+DXPyvNdLXpBolZMKOuC/yzzloWvACA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.14.2.tgz",
+      "integrity": "sha512-97y/95EzDC86jM2bKYacKk4n59miFC+WXueRdW5TeVzBw2UTL2Alvy36AZuyMUgBqxZdJSv88/q0jHTw7LvyMA==",
       "dev": true,
       "dependencies": {
         "@cloudflare/workers-types": "^4.20221111.1",
-        "@miniflare/cache": "2.14.1",
-        "@miniflare/core": "2.14.1",
-        "@miniflare/d1": "2.14.1",
-        "@miniflare/durable-objects": "2.14.1",
-        "@miniflare/html-rewriter": "2.14.1",
-        "@miniflare/kv": "2.14.1",
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/r2": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/sites": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1",
-        "@miniflare/web-sockets": "2.14.1"
+        "@miniflare/cache": "2.14.2",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/d1": "2.14.2",
+        "@miniflare/durable-objects": "2.14.2",
+        "@miniflare/html-rewriter": "2.14.2",
+        "@miniflare/kv": "2.14.2",
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/r2": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/sites": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2",
+        "@miniflare/web-sockets": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.1.tgz",
-      "integrity": "sha512-AbbIcU6VBeaNqVgMiLMWN2a09eX3jZmjaEi0uKqufVDqW/QIz47/30aC0O9qTe+XYpi3jjph/Ux7uEY8Z+enMw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.2.tgz",
+      "integrity": "sha512-jFOx1G5kD+kTubsga6jcFbMdU2nSuNG2/EkojwuhYT8hYp3qd8duvPyh1V+OR2tMvM4FWu6jXPXNZNBHXHQaUQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-file": "2.14.1"
+        "@miniflare/kv": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-file": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.1.tgz",
-      "integrity": "sha512-faZu9tRSW6c/looVFI/ZhkdGsIc9NfNCbSl3jJRmm7xgyZ+/S+dQ5JtGVbVsUIX8YGWDyE2j3oWCGCjxGLEpkg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.2.tgz",
+      "integrity": "sha512-tn8rqMBeTtN+ICHQAMKQ0quHGYIkcyDK0qKW+Ic14gdfGDZx45BqXExQM9wTVqKtwAt85zp5eKVUYQCFfUx46Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1"
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.1.tgz",
-      "integrity": "sha512-lfQbQwopVWd4W5XzrYdp0rhk3dJpvSmv1Wwn9RhNO20WrcuoxpdSzbmpBahsgYVg+OheVaEbS6RpFqdmwwLTog==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.2.tgz",
+      "integrity": "sha512-9Wtz9mayHIY0LDsfpMGx+/sfKCq3eAQJzYY+ju1tTEaKR0sVAuO51wu0wbyldsjj9OcBcd2X32iPbIa7KcSZQQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.1.tgz",
-      "integrity": "sha512-dkFvetm5wk6pwunlYb/UkI0yFNb3otLpRm5RDywMUzqObEf+rCiNNAbJe3HUspr2ncZVAaRWcEaDh82vYK5cmw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.2.tgz",
+      "integrity": "sha512-/TL0np4uYDl+6MdseDApZmDdlJ6Y7AY5iDY0TvUQJG9nyBoCjX6w0Zn4SiKDwO6660rPtSqZ5c7HzbPhGb5vsA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.1.tgz",
-      "integrity": "sha512-3N//L5EjF7+xXd7qCLR2ylUwm8t2MKyGPGWEtRBrQ2xqYYWhewKTjlquHCOPU5Irnnd/4BhTmFA55MNrq7m4Nw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.2.tgz",
+      "integrity": "sha512-kpbVlznPuxNQahssQvZiNPQo/iPme7qV3WMQeg6TYNCkYD7n6vEqeFZ5E/eQgB59xCanpvw4Ci8y/+SdMK6BUg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "undici": "5.28.2",
         "ws": "^8.2.2"
       },
       "engines": {
         "node": ">=16.13"
-      }
-    },
-    "node_modules/@miniflare/web-sockets/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -962,9 +890,9 @@
       "integrity": "sha512-zK177o49c09sa8yEp2/OPfyh+I/SHY/SZ9kxYQC33F8PotrrZgJjY4X3yqu4BFX4lC7RYI1tSXBDQP9Yo9p6/w=="
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.5.tgz",
-      "integrity": "sha512-H3ZUx89KiPhYa9nalUXVVStSUFHuzYxt4yoazufpTTYW9rVUCzhh02V8CH2C8nE4libnK0UgFq5DFIe0DOhqow==",
+      "version": "7.6.9",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.9.tgz",
+      "integrity": "sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1258,21 +1186,6 @@
         "semver": "^7.0.0"
       }
     },
-    "node_modules/builtins/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1439,21 +1352,6 @@
       },
       "engines": {
         "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
-      }
-    },
-    "node_modules/concordance/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cookie": {
@@ -2454,9 +2352,9 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
+      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
@@ -2490,21 +2388,6 @@
         "parse-package-name": "^1.0.0",
         "semver": "^7.3.7",
         "validate-npm-package-name": "^4.0.0"
-      }
-    },
-    "node_modules/npx-import/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/once": {
@@ -2922,6 +2805,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -3207,9 +3105,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.3.tgz",
-      "integrity": "sha512-7lmhlz3K1+IKB6IUjkdzV2l0jKY8/0KguEMdEpzzXCug5pEGIp3DxUg0DEN65DrVoxHiRKpPORC/qzX+UglSkQ==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -3402,34 +3300,22 @@
       }
     },
     "node_modules/vitest-environment-miniflare": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.1.tgz",
-      "integrity": "sha512-efMpx9XnpjHeIN1lnEMO+4Ky9xSFM0VeG8Ilf+5Uyh8U8lNuJ+qTTfr76LQ6MQcNzkLMo4byh0YxaZo8QfIYrw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.2.tgz",
+      "integrity": "sha512-9bVoJ59m8RtW+KxXoQBTm+2ljZDTuN/yxth3VlIJV4oOpjLo7ambK+exWJmoU+2lcSf0WAC/610a3gJuAJJDTg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/runner-vm": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/shared-test-environment": "2.14.1",
-        "undici": "5.20.0"
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/runner-vm": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/shared-test-environment": "2.14.2",
+        "undici": "5.28.2"
       },
       "engines": {
         "node": ">=16.13"
       },
       "peerDependencies": {
         "vitest": ">=0.23.0"
-      }
-    },
-    "node_modules/vitest-environment-miniflare/node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
       }
     },
     "node_modules/well-known-symbols": {
@@ -4418,166 +4304,111 @@
       "dev": true
     },
     "@miniflare/cache": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.1.tgz",
-      "integrity": "sha512-f/o6UBV6UX+MlhjcEch73/wjQvvNo37dgYmP6Pn2ax1/mEHhJ7allNAqenmonT4djNeyB3eEYV3zUl54wCEwrg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.2.tgz",
+      "integrity": "sha512-XH218Y2jxSOfxG8EyuprBKhI/Fn6xLrb9A39niJBlzpiKXqr8skl/sy/sUL5tfvqEbEnqDagGne8zEcjM+1fBg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.20.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
+        "undici": "5.28.2"
       }
     },
     "@miniflare/core": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.1.tgz",
-      "integrity": "sha512-d+SGAda/VoXq+SKz04oq8ATUwQw5755L87fgPR8pTdR2YbWkxdbmEm1z2olOpDiUjcR86aN6NtCjY6tUC7fqaw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.2.tgz",
+      "integrity": "sha512-n/smm5ZTg7ilGM4fxO7Gxhbe573oc8Za06M3b2fO+lPWqF6NJcEKdCC+sJntVFbn3Cbbd2G1ChISmugPfmlCkQ==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/watcher": "2.14.1",
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/watcher": "2.14.2",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "urlpattern-polyfill": "^4.0.3"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
       }
     },
     "@miniflare/d1": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.1.tgz",
-      "integrity": "sha512-MulDDBsDD8o5DwiqdMeJZy2vLoMji+NWnLcuibSag2mayA0LJcp0eHezseZNkW+knciWR1gMP8Xpa4Q1KwkbKA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.2.tgz",
+      "integrity": "sha512-3NPJyBLbFfzz9VAAdIZrDRdRpyslVCJoZHQk0/0CX3z2mJIfcQzjZhox2cYCFNH8NMJ7pRg6AeSMPYAnDKECDg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.1.tgz",
-      "integrity": "sha512-T+oHGw5GcEIilkzrf0xDES7jzLVqcXJzSGsEIWqnBFLtdlKmrZF679ulRLBbyMVgvpQz6FRONh9jTH1XIiuObQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.2.tgz",
+      "integrity": "sha512-BfK+ZkJABoi7gd/O6WbpsO4GrgW+0dmOBWJDlNBxQ7GIpa+w3n9+SNnrYUxKzWlPSvz+TfTTk381B1z/Z87lPw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1",
-        "undici": "5.20.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2",
+        "undici": "5.28.2"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.1.tgz",
-      "integrity": "sha512-vp4uZXuEKhtIaxoXa7jgDAPItlzjbfoUqYWp+fwDKv4J4mfQnzzs/5hwjbE7+Ihm/KNI0zNi8P0sSWjIRFl6ng==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.2.tgz",
+      "integrity": "sha512-tu0kd9bj38uZ04loHb3sMI8kzUzZPgPOAJEdS9zmdSPh0uOkjCDf/TEkKsDdv2OFysyb0DRsIrwhPqCTIrPf1Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.20.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
+        "undici": "5.28.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.1.tgz",
-      "integrity": "sha512-Gp07Wcszle7ptsoO8mCtKQRs0AbQnYo1rgnxUcsTL3xJJaHXEA/B9EKSADS2XzJMeY4PgUOHU6Rf08OOF2yWag==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.2.tgz",
+      "integrity": "sha512-3rs4cJOGACT/U7NH7j4KD29ugXRYUiM0aGkvOEdFQtChXLsYClJljXpezTfJJxBwZjdS4F2UFTixtFcHp74UfA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/queues": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.1.tgz",
-      "integrity": "sha512-uBzrbBkIgtNoztDpmMMISg/brYtxLHRE7oTaN8OVnq3bG+3nF9kQC42HUz+Vg+sf65UlvhSaqkjllgx+fNtOxQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.2.tgz",
+      "integrity": "sha512-OylkRs4lOWKvGnX+Azab3nx+1qwC87M36/hkgAU1RRvVDCOxOrYLvNLUczFfgmgMBwpYsmmW8YOIASlI3p4Qgw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/r2": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.1.tgz",
-      "integrity": "sha512-grOMnGf2XSicbgxMYMBfWE37k/e7l5NnwXZIViQ+N06uksp+MLA8E6yKQNtvrWQS66TM8gBvMnWo96OFmYjb6Q==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.2.tgz",
+      "integrity": "sha512-uuc7dx6OqSQT8i0F2rsigfizXmInssRvvJAjoi1ltaNZNJCHH9l1PwHfaNc/XAuDjYmiCjtHDaPdRvZU9g9F3g==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "undici": "5.28.2"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.1.tgz",
-      "integrity": "sha512-UobsGM0ICVPDlJD54VPDSx0EXrIY3nJMXBy2zIFuuUOz4hQKXvMQ6jtAlJ8UNKer+XXI3Mb/9R/gfU8r6kxIMA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.2.tgz",
+      "integrity": "sha512-WlyxAQ+bv/9Pm/xnbpgAg7RNX4pz/q3flytUoo4z4OrRmNEuXrbMUsJZnH8dziqzrZ2gCLkYIEzeaTmSQKp5Jg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/shared": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.1.tgz",
-      "integrity": "sha512-73GnLtWn5iP936ctE6ZJrMqGu134KOoIIveq5Yd/B+NnbFfzpuzjCpkLrnqjkDdsxDbruXSb5eTR/SmAdpJxZQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.2.tgz",
+      "integrity": "sha512-dDnYIztz10zDQjaFJ8Gy9UaaBWZkw3NyhFdpX6tAeyPA/2lGvkftc42MYmNi8s5ljqkZAtKgWAJnSf2K75NCJw==",
       "dev": true,
       "requires": {
         "@types/better-sqlite3": "^7.6.0",
@@ -4587,86 +4418,75 @@
       }
     },
     "@miniflare/shared-test-environment": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.14.1.tgz",
-      "integrity": "sha512-hfactEWiHuHOmE29XFG8oLNCF6+HqjD6Mb80CzidcVmLlBTEtSC3PEF+DXPyvNdLXpBolZMKOuC/yzzloWvACA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.14.2.tgz",
+      "integrity": "sha512-97y/95EzDC86jM2bKYacKk4n59miFC+WXueRdW5TeVzBw2UTL2Alvy36AZuyMUgBqxZdJSv88/q0jHTw7LvyMA==",
       "dev": true,
       "requires": {
         "@cloudflare/workers-types": "^4.20221111.1",
-        "@miniflare/cache": "2.14.1",
-        "@miniflare/core": "2.14.1",
-        "@miniflare/d1": "2.14.1",
-        "@miniflare/durable-objects": "2.14.1",
-        "@miniflare/html-rewriter": "2.14.1",
-        "@miniflare/kv": "2.14.1",
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/r2": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/sites": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1",
-        "@miniflare/web-sockets": "2.14.1"
+        "@miniflare/cache": "2.14.2",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/d1": "2.14.2",
+        "@miniflare/durable-objects": "2.14.2",
+        "@miniflare/html-rewriter": "2.14.2",
+        "@miniflare/kv": "2.14.2",
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/r2": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/sites": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2",
+        "@miniflare/web-sockets": "2.14.2"
       }
     },
     "@miniflare/sites": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.1.tgz",
-      "integrity": "sha512-AbbIcU6VBeaNqVgMiLMWN2a09eX3jZmjaEi0uKqufVDqW/QIz47/30aC0O9qTe+XYpi3jjph/Ux7uEY8Z+enMw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.2.tgz",
+      "integrity": "sha512-jFOx1G5kD+kTubsga6jcFbMdU2nSuNG2/EkojwuhYT8hYp3qd8duvPyh1V+OR2tMvM4FWu6jXPXNZNBHXHQaUQ==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-file": "2.14.1"
+        "@miniflare/kv": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-file": "2.14.2"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.1.tgz",
-      "integrity": "sha512-faZu9tRSW6c/looVFI/ZhkdGsIc9NfNCbSl3jJRmm7xgyZ+/S+dQ5JtGVbVsUIX8YGWDyE2j3oWCGCjxGLEpkg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.2.tgz",
+      "integrity": "sha512-tn8rqMBeTtN+ICHQAMKQ0quHGYIkcyDK0qKW+Ic14gdfGDZx45BqXExQM9wTVqKtwAt85zp5eKVUYQCFfUx46Q==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/storage-memory": "2.14.1"
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/storage-memory": "2.14.2"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.1.tgz",
-      "integrity": "sha512-lfQbQwopVWd4W5XzrYdp0rhk3dJpvSmv1Wwn9RhNO20WrcuoxpdSzbmpBahsgYVg+OheVaEbS6RpFqdmwwLTog==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.2.tgz",
+      "integrity": "sha512-9Wtz9mayHIY0LDsfpMGx+/sfKCq3eAQJzYY+ju1tTEaKR0sVAuO51wu0wbyldsjj9OcBcd2X32iPbIa7KcSZQQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.1.tgz",
-      "integrity": "sha512-dkFvetm5wk6pwunlYb/UkI0yFNb3otLpRm5RDywMUzqObEf+rCiNNAbJe3HUspr2ncZVAaRWcEaDh82vYK5cmw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.2.tgz",
+      "integrity": "sha512-/TL0np4uYDl+6MdseDApZmDdlJ6Y7AY5iDY0TvUQJG9nyBoCjX6w0Zn4SiKDwO6660rPtSqZ5c7HzbPhGb5vsA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.14.1"
+        "@miniflare/shared": "2.14.2"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.1.tgz",
-      "integrity": "sha512-3N//L5EjF7+xXd7qCLR2ylUwm8t2MKyGPGWEtRBrQ2xqYYWhewKTjlquHCOPU5Irnnd/4BhTmFA55MNrq7m4Nw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.2.tgz",
+      "integrity": "sha512-kpbVlznPuxNQahssQvZiNPQo/iPme7qV3WMQeg6TYNCkYD7n6vEqeFZ5E/eQgB59xCanpvw4Ci8y/+SdMK6BUg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0",
+        "@miniflare/core": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "undici": "5.28.2",
         "ws": "^8.2.2"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -4701,9 +4521,9 @@
       "integrity": "sha512-zK177o49c09sa8yEp2/OPfyh+I/SHY/SZ9kxYQC33F8PotrrZgJjY4X3yqu4BFX4lC7RYI1tSXBDQP9Yo9p6/w=="
     },
     "@types/better-sqlite3": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.5.tgz",
-      "integrity": "sha512-H3ZUx89KiPhYa9nalUXVVStSUFHuzYxt4yoazufpTTYW9rVUCzhh02V8CH2C8nE4libnK0UgFq5DFIe0DOhqow==",
+      "version": "7.6.9",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.9.tgz",
+      "integrity": "sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4934,17 +4754,6 @@
       "dev": true,
       "requires": {
         "semver": "^7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "busboy": {
@@ -5074,17 +4883,6 @@
         "md5-hex": "^3.0.1",
         "semver": "^7.3.2",
         "well-known-symbols": "^2.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "cookie": {
@@ -5829,9 +5627,9 @@
       "dev": true
     },
     "npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
+      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
       "dev": true,
       "requires": {
         "path-key": "^4.0.0"
@@ -5855,17 +5653,6 @@
         "parse-package-name": "^1.0.0",
         "semver": "^7.3.7",
         "validate-npm-package-name": "^4.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "once": {
@@ -6155,6 +5942,15 @@
         "node-forge": "^1"
       }
     },
+    "semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -6368,9 +6164,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.3.tgz",
-      "integrity": "sha512-7lmhlz3K1+IKB6IUjkdzV2l0jKY8/0KguEMdEpzzXCug5pEGIp3DxUg0DEN65DrVoxHiRKpPORC/qzX+UglSkQ==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dev": true,
       "requires": {
         "@fastify/busboy": "^2.0.0"
@@ -6460,27 +6256,16 @@
       }
     },
     "vitest-environment-miniflare": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.1.tgz",
-      "integrity": "sha512-efMpx9XnpjHeIN1lnEMO+4Ky9xSFM0VeG8Ilf+5Uyh8U8lNuJ+qTTfr76LQ6MQcNzkLMo4byh0YxaZo8QfIYrw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.2.tgz",
+      "integrity": "sha512-9bVoJ59m8RtW+KxXoQBTm+2ljZDTuN/yxth3VlIJV4oOpjLo7ambK+exWJmoU+2lcSf0WAC/610a3gJuAJJDTg==",
       "dev": true,
       "requires": {
-        "@miniflare/queues": "2.14.1",
-        "@miniflare/runner-vm": "2.14.1",
-        "@miniflare/shared": "2.14.1",
-        "@miniflare/shared-test-environment": "2.14.1",
-        "undici": "5.20.0"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.20.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-          "dev": true,
-          "requires": {
-            "busboy": "^1.6.0"
-          }
-        }
+        "@miniflare/queues": "2.14.2",
+        "@miniflare/runner-vm": "2.14.2",
+        "@miniflare/shared": "2.14.2",
+        "@miniflare/shared-test-environment": "2.14.2",
+        "undici": "5.28.2"
       }
     },
     "well-known-symbols": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "miniflare": "3.20230918.0",
     "typescript": "^4.9.5",
     "vitest": "^0.31.4",
-    "vitest-environment-miniflare": "^2.14.1",
+    "vitest-environment-miniflare": "^2.14.2",
     "wrangler": "^3.19.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,158 +368,158 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@miniflare/cache@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.1.tgz"
-  integrity sha512-f/o6UBV6UX+MlhjcEch73/wjQvvNo37dgYmP6Pn2ax1/mEHhJ7allNAqenmonT4djNeyB3eEYV3zUl54wCEwrg==
+"@miniflare/cache@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/cache/-/cache-2.14.2.tgz#626d3eb899eeb850f3afd6bcdce452aa4234e333"
+  integrity sha512-XH218Y2jxSOfxG8EyuprBKhI/Fn6xLrb9A39niJBlzpiKXqr8skl/sy/sUL5tfvqEbEnqDagGne8zEcjM+1fBg==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
     http-cache-semantics "^4.1.0"
-    undici "5.20.0"
+    undici "5.28.2"
 
-"@miniflare/core@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/core/-/core-2.14.1.tgz"
-  integrity sha512-d+SGAda/VoXq+SKz04oq8ATUwQw5755L87fgPR8pTdR2YbWkxdbmEm1z2olOpDiUjcR86aN6NtCjY6tUC7fqaw==
+"@miniflare/core@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/core/-/core-2.14.2.tgz#6a08738cf2f72ea60f3b92c5ce3fb974dbaf6122"
+  integrity sha512-n/smm5ZTg7ilGM4fxO7Gxhbe573oc8Za06M3b2fO+lPWqF6NJcEKdCC+sJntVFbn3Cbbd2G1ChISmugPfmlCkQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
-    "@miniflare/queues" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/watcher" "2.14.1"
+    "@miniflare/queues" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/watcher" "2.14.2"
     busboy "^1.6.0"
     dotenv "^10.0.0"
     kleur "^4.1.4"
     set-cookie-parser "^2.4.8"
-    undici "5.20.0"
+    undici "5.28.2"
     urlpattern-polyfill "^4.0.3"
 
-"@miniflare/d1@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.1.tgz"
-  integrity sha512-MulDDBsDD8o5DwiqdMeJZy2vLoMji+NWnLcuibSag2mayA0LJcp0eHezseZNkW+knciWR1gMP8Xpa4Q1KwkbKA==
+"@miniflare/d1@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/d1/-/d1-2.14.2.tgz#0bb21db0a94e1a5ecffacc289da78aa65f02530a"
+  integrity sha512-3NPJyBLbFfzz9VAAdIZrDRdRpyslVCJoZHQk0/0CX3z2mJIfcQzjZhox2cYCFNH8NMJ7pRg6AeSMPYAnDKECDg==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/durable-objects@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.1.tgz"
-  integrity sha512-T+oHGw5GcEIilkzrf0xDES7jzLVqcXJzSGsEIWqnBFLtdlKmrZF679ulRLBbyMVgvpQz6FRONh9jTH1XIiuObQ==
+"@miniflare/durable-objects@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/durable-objects/-/durable-objects-2.14.2.tgz#f94c86d0124e3476c67622add009a38c7f779552"
+  integrity sha512-BfK+ZkJABoi7gd/O6WbpsO4GrgW+0dmOBWJDlNBxQ7GIpa+w3n9+SNnrYUxKzWlPSvz+TfTTk381B1z/Z87lPw==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/storage-memory" "2.14.1"
-    undici "5.20.0"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/storage-memory" "2.14.2"
+    undici "5.28.2"
 
-"@miniflare/html-rewriter@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.1.tgz"
-  integrity sha512-vp4uZXuEKhtIaxoXa7jgDAPItlzjbfoUqYWp+fwDKv4J4mfQnzzs/5hwjbE7+Ihm/KNI0zNi8P0sSWjIRFl6ng==
+"@miniflare/html-rewriter@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/html-rewriter/-/html-rewriter-2.14.2.tgz#1f699255a1f4b76f5118bb35f0cd346127b61bce"
+  integrity sha512-tu0kd9bj38uZ04loHb3sMI8kzUzZPgPOAJEdS9zmdSPh0uOkjCDf/TEkKsDdv2OFysyb0DRsIrwhPqCTIrPf1Q==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
     html-rewriter-wasm "^0.4.1"
-    undici "5.20.0"
+    undici "5.28.2"
 
-"@miniflare/kv@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.1.tgz"
-  integrity sha512-Gp07Wcszle7ptsoO8mCtKQRs0AbQnYo1rgnxUcsTL3xJJaHXEA/B9EKSADS2XzJMeY4PgUOHU6Rf08OOF2yWag==
+"@miniflare/kv@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/kv/-/kv-2.14.2.tgz#cbca1feb23338106b7c7a815bd4d38e08e6476b0"
+  integrity sha512-3rs4cJOGACT/U7NH7j4KD29ugXRYUiM0aGkvOEdFQtChXLsYClJljXpezTfJJxBwZjdS4F2UFTixtFcHp74UfA==
   dependencies:
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/queues@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.1.tgz"
-  integrity sha512-uBzrbBkIgtNoztDpmMMISg/brYtxLHRE7oTaN8OVnq3bG+3nF9kQC42HUz+Vg+sf65UlvhSaqkjllgx+fNtOxQ==
+"@miniflare/queues@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/queues/-/queues-2.14.2.tgz#c20b76948a720b257b748c5611b84623f6d17e55"
+  integrity sha512-OylkRs4lOWKvGnX+Azab3nx+1qwC87M36/hkgAU1RRvVDCOxOrYLvNLUczFfgmgMBwpYsmmW8YOIASlI3p4Qgw==
   dependencies:
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/r2@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.1.tgz"
-  integrity sha512-grOMnGf2XSicbgxMYMBfWE37k/e7l5NnwXZIViQ+N06uksp+MLA8E6yKQNtvrWQS66TM8gBvMnWo96OFmYjb6Q==
+"@miniflare/r2@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/r2/-/r2-2.14.2.tgz#7d970045c680c74859aa491180fdd6dfa187d39d"
+  integrity sha512-uuc7dx6OqSQT8i0F2rsigfizXmInssRvvJAjoi1ltaNZNJCHH9l1PwHfaNc/XAuDjYmiCjtHDaPdRvZU9g9F3g==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    undici "5.20.0"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    undici "5.28.2"
 
-"@miniflare/runner-vm@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.1.tgz"
-  integrity sha512-UobsGM0ICVPDlJD54VPDSx0EXrIY3nJMXBy2zIFuuUOz4hQKXvMQ6jtAlJ8UNKer+XXI3Mb/9R/gfU8r6kxIMA==
+"@miniflare/runner-vm@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/runner-vm/-/runner-vm-2.14.2.tgz#b108ee6ecdbdb84aaad94419b3be148df4cb3f18"
+  integrity sha512-WlyxAQ+bv/9Pm/xnbpgAg7RNX4pz/q3flytUoo4z4OrRmNEuXrbMUsJZnH8dziqzrZ2gCLkYIEzeaTmSQKp5Jg==
   dependencies:
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/shared-test-environment@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.14.1.tgz"
-  integrity sha512-hfactEWiHuHOmE29XFG8oLNCF6+HqjD6Mb80CzidcVmLlBTEtSC3PEF+DXPyvNdLXpBolZMKOuC/yzzloWvACA==
+"@miniflare/shared-test-environment@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/shared-test-environment/-/shared-test-environment-2.14.2.tgz#a0a3a37c6d0c0fb94ab7e9bd56c8748651ff6091"
+  integrity sha512-97y/95EzDC86jM2bKYacKk4n59miFC+WXueRdW5TeVzBw2UTL2Alvy36AZuyMUgBqxZdJSv88/q0jHTw7LvyMA==
   dependencies:
     "@cloudflare/workers-types" "^4.20221111.1"
-    "@miniflare/cache" "2.14.1"
-    "@miniflare/core" "2.14.1"
-    "@miniflare/d1" "2.14.1"
-    "@miniflare/durable-objects" "2.14.1"
-    "@miniflare/html-rewriter" "2.14.1"
-    "@miniflare/kv" "2.14.1"
-    "@miniflare/queues" "2.14.1"
-    "@miniflare/r2" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/sites" "2.14.1"
-    "@miniflare/storage-memory" "2.14.1"
-    "@miniflare/web-sockets" "2.14.1"
+    "@miniflare/cache" "2.14.2"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/d1" "2.14.2"
+    "@miniflare/durable-objects" "2.14.2"
+    "@miniflare/html-rewriter" "2.14.2"
+    "@miniflare/kv" "2.14.2"
+    "@miniflare/queues" "2.14.2"
+    "@miniflare/r2" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/sites" "2.14.2"
+    "@miniflare/storage-memory" "2.14.2"
+    "@miniflare/web-sockets" "2.14.2"
 
-"@miniflare/shared@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.1.tgz"
-  integrity sha512-73GnLtWn5iP936ctE6ZJrMqGu134KOoIIveq5Yd/B+NnbFfzpuzjCpkLrnqjkDdsxDbruXSb5eTR/SmAdpJxZQ==
+"@miniflare/shared@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/shared/-/shared-2.14.2.tgz#ee49f2989a18b30747415dd1f90da7ae851fea90"
+  integrity sha512-dDnYIztz10zDQjaFJ8Gy9UaaBWZkw3NyhFdpX6tAeyPA/2lGvkftc42MYmNi8s5ljqkZAtKgWAJnSf2K75NCJw==
   dependencies:
     "@types/better-sqlite3" "^7.6.0"
     kleur "^4.1.4"
     npx-import "^1.1.4"
     picomatch "^2.3.1"
 
-"@miniflare/sites@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.1.tgz"
-  integrity sha512-AbbIcU6VBeaNqVgMiLMWN2a09eX3jZmjaEi0uKqufVDqW/QIz47/30aC0O9qTe+XYpi3jjph/Ux7uEY8Z+enMw==
+"@miniflare/sites@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/sites/-/sites-2.14.2.tgz#6b77f9cf0b6bf07f38c980e8e21c3dcfbd4fd867"
+  integrity sha512-jFOx1G5kD+kTubsga6jcFbMdU2nSuNG2/EkojwuhYT8hYp3qd8duvPyh1V+OR2tMvM4FWu6jXPXNZNBHXHQaUQ==
   dependencies:
-    "@miniflare/kv" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/storage-file" "2.14.1"
+    "@miniflare/kv" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/storage-file" "2.14.2"
 
-"@miniflare/storage-file@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.1.tgz"
-  integrity sha512-faZu9tRSW6c/looVFI/ZhkdGsIc9NfNCbSl3jJRmm7xgyZ+/S+dQ5JtGVbVsUIX8YGWDyE2j3oWCGCjxGLEpkg==
+"@miniflare/storage-file@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/storage-file/-/storage-file-2.14.2.tgz#d180b9f1a32f92497ac5993b008e9eddfba938e6"
+  integrity sha512-tn8rqMBeTtN+ICHQAMKQ0quHGYIkcyDK0qKW+Ic14gdfGDZx45BqXExQM9wTVqKtwAt85zp5eKVUYQCFfUx46Q==
   dependencies:
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/storage-memory" "2.14.1"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/storage-memory" "2.14.2"
 
-"@miniflare/storage-memory@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.1.tgz"
-  integrity sha512-lfQbQwopVWd4W5XzrYdp0rhk3dJpvSmv1Wwn9RhNO20WrcuoxpdSzbmpBahsgYVg+OheVaEbS6RpFqdmwwLTog==
+"@miniflare/storage-memory@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/storage-memory/-/storage-memory-2.14.2.tgz#b4eac56ddeca8b839f10cce62914a7c843e44f70"
+  integrity sha512-9Wtz9mayHIY0LDsfpMGx+/sfKCq3eAQJzYY+ju1tTEaKR0sVAuO51wu0wbyldsjj9OcBcd2X32iPbIa7KcSZQQ==
   dependencies:
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/watcher@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.1.tgz"
-  integrity sha512-dkFvetm5wk6pwunlYb/UkI0yFNb3otLpRm5RDywMUzqObEf+rCiNNAbJe3HUspr2ncZVAaRWcEaDh82vYK5cmw==
+"@miniflare/watcher@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/watcher/-/watcher-2.14.2.tgz#619f2f6dff630eddf9f690b611cc9669fdedb900"
+  integrity sha512-/TL0np4uYDl+6MdseDApZmDdlJ6Y7AY5iDY0TvUQJG9nyBoCjX6w0Zn4SiKDwO6660rPtSqZ5c7HzbPhGb5vsA==
   dependencies:
-    "@miniflare/shared" "2.14.1"
+    "@miniflare/shared" "2.14.2"
 
-"@miniflare/web-sockets@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.1.tgz"
-  integrity sha512-3N//L5EjF7+xXd7qCLR2ylUwm8t2MKyGPGWEtRBrQ2xqYYWhewKTjlquHCOPU5Irnnd/4BhTmFA55MNrq7m4Nw==
+"@miniflare/web-sockets@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@miniflare/web-sockets/-/web-sockets-2.14.2.tgz#8a7a1eead842aa96e0632382d0807c141a29037b"
+  integrity sha512-kpbVlznPuxNQahssQvZiNPQo/iPme7qV3WMQeg6TYNCkYD7n6vEqeFZ5E/eQgB59xCanpvw4Ci8y/+SdMK6BUg==
   dependencies:
-    "@miniflare/core" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    undici "5.20.0"
+    "@miniflare/core" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    undici "5.28.2"
     ws "^8.2.2"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -1930,17 +1930,10 @@ ufo@^1.3.0:
   resolved "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz"
   integrity sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==
 
-undici@5.20.0:
-  version "5.20.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz"
-  integrity sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==
-  dependencies:
-    busboy "^1.6.0"
-
-undici@^5.22.1:
-  version "5.25.3"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.25.3.tgz"
-  integrity sha512-7lmhlz3K1+IKB6IUjkdzV2l0jKY8/0KguEMdEpzzXCug5pEGIp3DxUg0DEN65DrVoxHiRKpPORC/qzX+UglSkQ==
+undici@5.28.2, undici@^5.22.1:
+  version "5.28.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.2.tgz#fea200eac65fc7ecaff80a023d1a0543423b4c91"
+  integrity sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
@@ -1986,16 +1979,16 @@ vite-node@0.31.4:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest-environment-miniflare@^2.14.1:
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.1.tgz"
-  integrity sha512-efMpx9XnpjHeIN1lnEMO+4Ky9xSFM0VeG8Ilf+5Uyh8U8lNuJ+qTTfr76LQ6MQcNzkLMo4byh0YxaZo8QfIYrw==
+vitest-environment-miniflare@^2.14.2:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/vitest-environment-miniflare/-/vitest-environment-miniflare-2.14.2.tgz#3e5c49bf976ffa4f61d25b0f7be0475f29a31745"
+  integrity sha512-9bVoJ59m8RtW+KxXoQBTm+2ljZDTuN/yxth3VlIJV4oOpjLo7ambK+exWJmoU+2lcSf0WAC/610a3gJuAJJDTg==
   dependencies:
-    "@miniflare/queues" "2.14.1"
-    "@miniflare/runner-vm" "2.14.1"
-    "@miniflare/shared" "2.14.1"
-    "@miniflare/shared-test-environment" "2.14.1"
-    undici "5.20.0"
+    "@miniflare/queues" "2.14.2"
+    "@miniflare/runner-vm" "2.14.2"
+    "@miniflare/shared" "2.14.2"
+    "@miniflare/shared-test-environment" "2.14.2"
+    undici "5.28.2"
 
 vitest@^0.31.4:
   version "0.31.4"


### PR DESCRIPTION
Bumps [undici](https://github.com/nodejs/undici) to 5.28.2 and updates ancestor dependency [vitest-environment-miniflare](https://github.com/cloudflare/miniflare/tree/HEAD/packages/vitest-environment-miniflare). These dependencies need to be updated together.


Updates `undici` from 5.25.3 to 5.28.2
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.25.3...v5.28.2)

Updates `vitest-environment-miniflare` from 2.14.1 to 2.14.2
- [Release notes](https://github.com/cloudflare/miniflare/releases)
- [Changelog](https://github.com/cloudflare/miniflare/blob/master/docs/CHANGELOG.md)
- [Commits](https://github.com/cloudflare/miniflare/commits/v2.14.2/packages/vitest-environment-miniflare)

---
updated-dependencies:
- dependency-name: undici dependency-type: indirect
- dependency-name: vitest-environment-miniflare dependency-type: direct:development ...

Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3
